### PR TITLE
feat: Add passlord to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Welcome to the ultimate curated list of **Cybersecurity Tools**, organized by ca
 | **GnuPG** | Encryption and signing of data | https://gnupg.org/ |
 | **Hashcat** | Password recovery tool | https://hashcat.net/hashcat/ |
 | **John the Ripper** | Password cracking | https://www.openwall.com/john/ |
+| **Passlord** | Profile-based wordlist generator | https://github.com/navnee1h/passlord/ |
 
 ---
 


### PR DESCRIPTION
feat(cryptography): Add passlord wordlist generator

This commit introduces 'passlord', a powerful profile-based wordlist generator, to the list of cybersecurity tools.

Passlord specializes in creating highly customized and targeted password lists from personal information, which is a crucial step in modern password cracking and dictionary attacks.

It has been placed in the 'Cryptography' section because its function directly complements existing tools like Hashcat and John the Ripper, which rely on quality wordlists as input.

Link: https://github.com/navnee1h/passlord/